### PR TITLE
fix: ARG usage for Containerfile

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -150,7 +150,7 @@ jobs:
         run: |
           just=$(which just)
 
-          sudo $just build "${{ steps.image_case.outputs.lowercase }}" "${{ matrix.variant }}" stable
+          sudo $just build "${{ steps.image_case.outputs.lowercase }}" "${{ matrix.variant }}"
 
       - name: Generate tags
         id: tags


### PR DESCRIPTION
I didn't configure the ARG usage correctly and we didn't make use of the
variants of veneos we needed.

- `veneos` now maps to `ghcr.io/ublue-os/bazzite-gnome`
- `veneos-server` now maps to `ghcr.io/ublue-os/ucore-hci`

Also removed some ARGs from the template.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
