### PR TITLE
chore: Remove unused metadata step

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -80,37 +80,6 @@ jobs:
           # https://linux.die.net/man/1/date
           echo "date=$(date -u +%Y\-%m\-%d\T%H\:%M\:%S\Z)" >> $GITHUB_OUTPUT
 
-      # Image metadata for https://artifacthub.io/
-      - name: Image Metadata
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
-        id: metadata
-        with:
-          tags: |
-            type=raw,value=latest,enable=${{ matrix.variant == 'stable' }}
-            type=raw,value=${{ matrix.variant }}
-            type=raw,value=${{ matrix.variant }}.{{date 'YYYYMMDD'}}
-            type=sha,enable=${{ github.event_name == 'pull_request' }}
-            type=ref,event=pr
-          labels: |
-            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}/refs/heads/main/README.md
-            org.opencontainers.image.created=${{ steps.date.outputs.date }}
-            org.opencontainers.image.description=${{ env.IMAGE_DESC }}
-            org.opencontainers.image.documentation=https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}/refs/heads/main/README.md
-            org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}/blob/main/Containerfile
-            org.opencontainers.image.title=${{ inputs.image_flavor }}
-            org.opencontainers.image.url=https://github.com/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
-            org.opencontainers.image.vendor=${{ github.repository_owner }}
-            org.opencontainers.image.version=${{ matrix.variant }}.{{date 'YYYYMMDD'}}
-            io.artifacthub.package.deprecated=false
-            io.artifacthub.package.keywords=bootc,ostree,ublue,universal-blue,veneos${{ inputs.image_flavor == 'veneos-server' && ',coreos,ucore' || ',bazzite' }}
-            io.artifacthub.package.license=Apache-2.0
-            io.artifacthub.package.logo-url=${{ env.ARTIFACTHUB_LOGO_URL }}
-            io.artifacthub.package.prerelease=false
-            io.artifacthub.package.maintainers=[{"name":"Freya Gustavsson","email":"freya@venefilyn.se"}]
-            containers.bootc=1
-          sep-tags: " "
-          sep-annotations: " "
-
       - name: Setup Just
         # yamllint disable-line rule:line-length rule:comments
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
@@ -162,6 +131,7 @@ jobs:
 
           tags=$(sudo $just generate-build-tags "${{ matrix.variant }}" "${{ env.PR_NUMBER }}")
           echo "tags=$tags" >> $GITHUB_OUTPUT
+
       # Tag Images
       - name: Tag Images
         run: |


### PR DESCRIPTION
We now set the labels through the Justfile instead of relying on the CI
to take care of it. Makes it more reproducible locally.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
