### PR TITLE
feat: Add Cockpit Files app

### DIFF
--- a/build_files/desktop-packages.sh
+++ b/build_files/desktop-packages.sh
@@ -36,10 +36,6 @@ LAYERED_PACKAGES=(
     btop
     bun
     cheat
-    cockpit
-    cockpit-machines
-    cockpit-ostree
-    cockpit-sosreport
     cosign
     devpod
     devpod-desktop

--- a/build_files/server-packages.sh
+++ b/build_files/server-packages.sh
@@ -7,6 +7,11 @@ set ${SET_X:+-x} -eou pipefail
 
 SERVER_PACKAGES=(
     borgbackup
+    cockpit
+    cockpit-files
+    cockpit-machines
+    cockpit-ostree
+    cockpit-sosreport
     jq
     just
     python3-ramalama


### PR DESCRIPTION
Previously missing from the list. This also moves the Cockpit files from
desktop to server packages to make them be installed by default within
the uCore-based veneos-server.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
