### PR TITLE
chore: Move terminal pkgs to server

### DIFF
--- a/build_files/desktop-packages.sh
+++ b/build_files/desktop-packages.sh
@@ -42,7 +42,6 @@ LAYERED_PACKAGES=(
     direnv
     eza
     fira-code-fonts
-    fish
     gh
     ghostty
     gphoto2
@@ -71,7 +70,6 @@ LAYERED_PACKAGES=(
     yq
     yubikey-manager
     zoxide
-    zsh
 )
 dnf5 install --setopt=install_weak_deps=False -y "${LAYERED_PACKAGES[@]}"
 

--- a/build_files/server-packages.sh
+++ b/build_files/server-packages.sh
@@ -12,6 +12,7 @@ SERVER_PACKAGES=(
     cockpit-machines
     cockpit-ostree
     cockpit-sosreport
+    fish
     jq
     just
     python3-ramalama
@@ -19,6 +20,7 @@ SERVER_PACKAGES=(
     tmux
     udica
     yq
+    zsh
 )
 
 dnf5 install --setopt=install_weak_deps=False -y "${SERVER_PACKAGES[@]}"


### PR DESCRIPTION
Adds zsh, fish, and starship to server image as well. Remains installed
by default on desktop as usual.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
