### PR TITLE
feat: Drop `veneos-bootc` image

### DIFF
--- a/.github/actions/get-images/action.yml
+++ b/.github/actions/get-images/action.yml
@@ -3,7 +3,7 @@ name: Get images to Build
 description: Get images and variants for building VeneOS
 inputs:
   image_flavor:
-    description: "Types of Image to Build (veneos, veneos-server, veneos-bootc)"
+    description: "Types of Image to Build (veneos, veneos-server)"
     required: true
 outputs:
   image:
@@ -25,9 +25,6 @@ runs:
         "veneos")
           image="ghcr.io/ublue-os/bazzite-gnome"
           ;;
-        "veneos-bootc")
-          image="ghcr.io/ublue-os/cayo"
-          ;;
         "veneos-server")
           image="ghcr.io/ublue-os/ucore-hci"
           ;;
@@ -40,10 +37,6 @@ runs:
       run: |-
         # Array to Hold Image Names
         case "${{ inputs.image_flavor }}" in
-        "veneos-bootc")
-          # variants=("latest")
-          variants=("prerelease")
-          ;;
         *)
           variants=("stable" "testing")
           ;;

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -8,7 +8,6 @@ on:
         type: choice
         options:
           - "veneos"
-          - "veneos-bootc"
           - "veneos-server"
         default: "veneos"
   workflow_call:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_flavor: ["veneos", "veneos-server", "veneos-bootc"]
+        image_flavor: ["veneos", "veneos-server"]
     with:
       image_flavor: ${{ matrix.image_flavor }}
 

--- a/Justfile
+++ b/Justfile
@@ -155,9 +155,6 @@ build $target_image=image_name $tag=default_tag:
 
     keywords=("bootc" "ostree" "ublue" "universal-blue" "veneos")
     case "$target_image" in
-    "veneos-bootc")
-        keywords+=("cayo" "bootc")
-        ;;
     "veneos-server")
         keywords+=("coreos" "ucore")
         ;;

--- a/README.md
+++ b/README.md
@@ -19,23 +19,16 @@ Primarily intended for myself.
 - Optimized for AMD GPU
 - [Bazzite features](https://github.com/ublue-os/bazzite#about--features)
 
-### Bootc 
-
-> [!NOTE]
-> `veneos-bootc` is in in early stages and is subject to change.
-
-- Built on Fedora Bootc
-- Uses [Cayo Fedora](https://github.com/ublue-os/cayo)
-- Cockpit installed
-
 ### Server
 
 > [!CAUTION]
-> `veneos-server` has never been deployed and is not regularly tested, proceed at your own risk.
+> `veneos-server` is still being developed and is yet to be tested in a live system.
 
 - Built on Fedora CoreOS
 - Uses [uCore Hyper-Coverged Infrastructure (HCI)](https://github.com/ublue-os/ucore)
-- Cockpit installed
+- Cockpit is preinstalled
+- `zsh` and `fish` is preinstalled
+- Starship prompt is preinstalled
 
 ## Features
 
@@ -66,38 +59,6 @@ sudo bootc switch --enforce-container-sigpolicy ghcr.io/venefilyn/veneos:latest
 If you want to install the image on a new system download and install Bazzite ISO first:
 
 <https://download.bazzite.gg/bazzite-stable-amd64.iso>
-
-### Bootc
-
-#### Existing installation
-
-> [!IMPORTANT]
-> This is executed within a Fedora CoreOS LiveUSB boot.
-
-> [!NOTE]
-> Command below assumes `/dev/sda` is the one you want to install to.
-
-To install on a fresh system through LiveUSB, add the SSH keys that will be used to access the system.
-This is easiest done through a fileserver setup on another machine. 
-
-```bash
-mkdir .ssh
-curl http://lab-server/id_rsa.pub > .ssh/authorized_keys
-```
-
-Then you can install through `podman`
-
-```bash
-sudo podman run \
-      --rm --privileged \
-      --pid=host \
-      -v /dev:/dev \
-      -v /var/lib/containers:/var/lib/containers \
-      -v ~/.ssh:/temp \
-      --security-opt label=type:unconfined_t \
-      ghcr.io/venefilyn/bootc:latest \
-      bootc install to-disk /dev/sda --root-ssh-authorized-keys /temp/authorized_keys --filesystem xfs
-```
 
 ### Server
 Based on CoreOS.

--- a/images.yml
+++ b/images.yml
@@ -16,10 +16,3 @@ images:
         upstream: stable
       - base: testing
         upstream: testing
-
-  - name: veneos-bootc
-    id: BOOTC
-    image: ghcr.io/ublue-os/cayo
-    mapping:
-      - base: prerelease
-        upstream: fedora


### PR DESCRIPTION
There are movements within CoreOS and Universal Blue that makes uCore
and Fedora CoreOS more relevant to me for homelab setup than Cayo
itself.

Some discussions were seen in the Universal Blue Discord server that
indicates that Cayo will eventually not be too different from uCore as
Fedora CoreOS due to Fedora CoreOS soon adopting bootc.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
