### PR TITLE
feat: Add `podman-gvproxy`

### DIFF
--- a/build_files/desktop-packages.sh
+++ b/build_files/desktop-packages.sh
@@ -57,7 +57,6 @@ LAYERED_PACKAGES=(
     nodejs-npm
     pnpm
     podlet
-    podman-compose
     podman-remote
     pre-commit
     rbw

--- a/build_files/server-packages.sh
+++ b/build_files/server-packages.sh
@@ -17,6 +17,9 @@ SERVER_PACKAGES=(
     fish
     jq
     just
+    podman
+    podman-compose
+    podman-gvproxy
     python3-ramalama
     skopeo
     tmux


### PR DESCRIPTION
Makes it possible to use VMs with podman. Also moved podman deps to
server as this is relevant to server management as well.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
