### PR TITLE
fix: Change `podman-gvproxy` to `podman-machine`

### DIFF
--- a/build_files/server-packages.sh
+++ b/build_files/server-packages.sh
@@ -19,7 +19,7 @@ SERVER_PACKAGES=(
     just
     podman
     podman-compose
-    podman-gvproxy
+    podman-machine
     python3-ramalama
     skopeo
     tmux


### PR DESCRIPTION
The `podman-gvproxy` pkg is just an alias and also something that
`podman-machine` has a dep. We run into more issues that require more
work and this is the proper package anyway - despite the lacking docs.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
