### PR TITLE
feat: Add `git-credential-libsecret`

### DIFF
--- a/build_files/desktop-packages.sh
+++ b/build_files/desktop-packages.sh
@@ -48,6 +48,7 @@ LAYERED_PACKAGES=(
     fira-code-fonts
     gh
     ghostty
+    git-credential-libsecret
     gphoto2
     grc
     helix


### PR DESCRIPTION
Allows for secure credential storage using GNOME Keyring.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
