### PR TITLE
fix: Prevent Podman healthcheck spam

### DIFF
--- a/system_files/etc/containers/containers.conf.d/no-podman-systemd-spam.conf
+++ b/system_files/etc/containers/containers.conf.d/no-podman-systemd-spam.conf
@@ -1,0 +1,2 @@
+[engine]
+healthcheck_events = false


### PR DESCRIPTION
This is an issue when you have lots of containers running which can clog
up your journal.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
