### PR TITLE
chore: Remove jsonata Renovate manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,17 +14,6 @@
       ],
       datasourceTemplate: 'docker',
     },
-    {
-      customType: "jsonata",
-      managerFilePatterns: [
-        "/^images.ya?ml$/",
-      ],
-      fileFormat: "yaml",
-      datasourceTemplate: "docker",
-      matchStrings: [
-        'images.$map(mapping, function($v, $k, $a) { { "currentValue": $v.upstream, "currentDigest": $v.upstreamDigest, "depName": $.image } })'
-      ]
-    }
   ],
   packageRules: [
     {


### PR DESCRIPTION
Should work without it

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
