### PR TITLE
fix: Remove ujust command cleanup

### DIFF
--- a/build_files/just-files.sh
+++ b/build_files/just-files.sh
@@ -14,12 +14,3 @@ log() {
 log "Adding VeneOS just recipes"
 
 echo "import \"/usr/share/veneos/just/vene.just\"" >>/usr/share/ublue-os/justfile
-
-log "Hide incompatible Bazzite just recipes"
-for recipe in "bazzite-cli" "install-coolercontrol" "install-openrgb" ; do
-  if ! grep -l "^$recipe:" /usr/share/ublue-os/just/*.just | grep -q .; then
-    echo "Error: Recipe $recipe not found in any just file"
-    exit 1
-  fi
-  sed -i "s/^$recipe:/_$recipe:/" /usr/share/ublue-os/just/*.just
-done


### PR DESCRIPTION
Removing the recipes from Bazzite was good in theory but a bit of a
hassle to maintain. For now I'll just remove the cleanup

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
