### PR TITLE
feat: add libheif for HEIC conversions

### DIFF
--- a/build_files/desktop-packages.sh
+++ b/build_files/desktop-packages.sh
@@ -53,6 +53,7 @@ LAYERED_PACKAGES=(
     grc
     helix
     krb5-workstation
+    libheif
     libinput-devel
     libva-utils
     libvirt vagrant


### PR DESCRIPTION
Makes it possible to use ImageMagick for converting HEIC files

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
