### PR TITLE
upstream: Use chunkah and match Aurora

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -37,7 +37,7 @@ jobs:
       actions: read
     outputs:
       variants: ${{ steps.variants.outputs.variants }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -57,7 +57,7 @@ jobs:
   build_push:
     name: Build ${{ inputs.image }}:${{ matrix.variant }} image and publish
     needs: get-variants
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     permissions:
       contents: read

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -19,9 +19,10 @@ on:
         required: true
 
 env:
-  IMAGE_NAME: "${{ github.event.repository.name }}" # the name of the image produced by this build, matches repo names
-  IMAGE_DESC: "${{ github.event.repository.description }}"
-  IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}" # do not edit
+  IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"  # do not edit
+  # IMAGE_NAME: "${{ github.event.repository.name }}" # the name of the image produced by this build, matches repo names
+  # IMAGE_DESC: "${{ github.event.repository.description }}"
+  # IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}" # do not edit
   ARTIFACTHUB_LOGO_URL: "https://avatars.githubusercontent.com/u/6598829?s=200&v=4" # You should put your own image here so that you get a fancy profile image on https://artifacthub.io/!
   SET_X: 1
 
@@ -72,41 +73,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6
+
+      - name: Install Just
+        # yamllint disable-line rule:line-length rule:comments
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      - name: Check Just Syntax
+        shell: bash
+        run: |
+          just --version
+          just check
+
       # Needed to add ArtifactHub manifest
       - name: Install ORAS
         id: install_oras
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
 
-      - name: Get current date
-        id: date
+      - name: Prepare environment
+        env:
+          IMAGE_NAME: ${{ inputs.image }}
         run: |
-          # This generates a timestamp like what is defined on the ArtifactHub documentation
-          # E.g: 2022-02-08T15:38:15Z'
-          # https://artifacthub.io/docs/topics/repositories/container-images/
-          # https://linux.die.net/man/1/date
-          echo "date=$(date -u +%Y\-%m\-%d\T%H\:%M\:%S\Z)" >> $GITHUB_OUTPUT
-
-      - name: Setup Just
-        # yamllint disable-line rule:line-length rule:comments
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-
-      # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
-      # https://github.com/macbre/push-to-ghcr/issues/12
-      - name: Lowercase Registry
-        id: registry_case
-        uses: ASzc/change-string-case-action@ecd1412d078f2e06e9eedcbaa6fcd988151c3f82 # v8
-        with:
-          string: ${{ env.IMAGE_REGISTRY }}
-
-      - name: Lowercase Image
-        id: image_case
-        uses: ASzc/change-string-case-action@ecd1412d078f2e06e9eedcbaa6fcd988151c3f82 # v8
-        with:
-          string: ${{ inputs.image }}
+          # Lowercase the image uri https://github.com/macbre/push-to-ghcr/issues/12
+          echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> ${GITHUB_ENV}
 
       # Verify the container image and if it fails, we just don't push this at all
       # Something is up and we need to manually check
@@ -116,7 +107,7 @@ jobs:
         run: |
           just=$(which just)
 
-          sudo $just cosign-verify-image "${{ steps.image_case.outputs.lowercase }}" "${{ matrix.variant }}"
+          sudo $just cosign-verify-image "${IMAGE_NAME}" "${{ matrix.variant }}"
 
       - name: Build Image
         id: build_image
@@ -125,7 +116,7 @@ jobs:
         run: |
           just=$(which just)
 
-          sudo $just build "${{ steps.image_case.outputs.lowercase }}" "${{ matrix.variant }}"
+          sudo $just build "${IMAGE_NAME}" "${{ matrix.variant }}"
 
       - name: Get Fedora version
         if: inputs.image != 'veneos-server'
@@ -155,9 +146,9 @@ jobs:
           set ${SET_X:+-x}
           just=$(which just)
 
-          IMAGE="localhost/${{ steps.image_case.outputs.lowercase }}:${{ matrix.variant }}"
+          IMAGE="localhost/${IMAGE_NAME}:${{ matrix.variant }}"
 
-          sudo $just rechunk "${{ steps.image_case.outputs.lowercase }}" "${{ matrix.variant }}"
+          sudo $just rechunk "${IMAGE_NAME}" "${{ matrix.variant }}"
 
           IMAGE_DIGEST=$(sudo podman image inspect --format '{{.Digest}}' $IMAGE)
           echo "image=$IMAGE" >> $GITHUB_OUTPUT
@@ -167,7 +158,7 @@ jobs:
       - name: Tag Images
         run: |
           just=$(which just)
-          sudo $just tag-images "${{ steps.image_case.outputs.lowercase }}" \
+          sudo $just tag-images "${IMAGE_NAME}" \
                         "${{ matrix.variant }}" \
                         "${{ steps.tags.outputs.tags }}"
 
@@ -182,7 +173,7 @@ jobs:
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           oras push \
-            ghcr.io/${{ steps.registry_case.outputs.lowercase }}/${{ steps.image_case.outputs.lowercase }}:artifacthub.io \
+            ${IMAGE_REGISTRY}/${IMAGE_NAME}:artifacthub.io \
             --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
             artifacthub-${{ inputs.image }}-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
 
@@ -199,9 +190,16 @@ jobs:
 
           sudo $just login-to-ghcr ${{ env.ACTOR }} ${{ env.TOKEN }}
 
-          digest=$(sudo $just push-to-registry "${{ steps.image_case.outputs.lowercase }}" "${{ matrix.variant }}" "${{ steps.tags.outputs.tags }}" "${{ env.IMAGE_REGISTRY }}")
+          digest=$(sudo $just push-to-registry "${IMAGE_NAME}" "${{ matrix.variant }}" "${{ steps.tags.outputs.tags }}" "${ IMAGE_REGISTRY }")
 
           echo "digest=$digest" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        # https://github.com/containers/container-libs/issues/388
+        with:
+          cosign-release: 'v3.1.2'
 
       # Signing container image so anyone and ourselves can easily verify its authenticity
       # for future updates.
@@ -212,5 +210,7 @@ jobs:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
         run: |
-          IMAGE_FULL="${{ steps.registry_case.outputs.lowercase }}/${{ steps.image_case.outputs.lowercase }}"
-          cosign sign -y  --key env://COSIGN_PRIVATE_KEY --new-bundle-format=false $IMAGE_FULL@${{ env.DIGEST }}
+          # https://github.com/containers/container-libs/issues/388
+          # https://github.com/coreos/rpm-ostree/issues/5509
+          # use old bundle format, so we can use newer cosign 3.X.X instead of 2.X.X
+          cosign sign -y --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${DIGEST}

--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -22,7 +22,7 @@ permissions: {}
 name: Generate Release
 jobs:
   generate-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
     strategy:

--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,6 @@
-just := just_executable()
+set dotenv-filename := "veneos.env"
+set dotenv-load
+
 export repo_organization := env("GITHUB_REPOSITORY_OWNER", "Venefilyn")
 export image_name := env("IMAGE_NAME", "veneos")
 export repo_image_name := lowercase(repo_organization) / lowercase(image_name)
@@ -27,6 +29,14 @@ rechunker := "ghcr.io/hhd-dev/rechunk:v1.2.4@sha256:8a84bd5a029681aa8db523f927b7
 cosign-installer := "ghcr.io/sigstore/cosign/cosign:v2.4.1"
 [private]
 syft-installer := "ghcr.io/anchore/syft:v1.51.0@sha256:678bfa565b60f747aac0f8e964fe5588a24445b8d0a480e91f6efd70020dfbb0"
+[private]
+chunkah := shell("yq -r \".images[] | select(.name == \\\"chunkah\\\") | \\\"\\\\(.image)@\\\\(.digest)\\\"\" image-versions.yml")
+
+export SUDO_DISPLAY := if `if [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then echo true; fi` == "true" { "true" } else { "false" }
+export SUDOIF := if `id -u` == "0" { "" } else { "sudo" }
+export PODMAN := "podman"
+export BUILDAH := "buildah"
+just := just_executable()
 
 [private]
 default:
@@ -71,25 +81,7 @@ clean:
 [group('Utility')]
 [private]
 sudo-clean:
-    {{ just }} sudoif {{ just }} clean
-
-# sudoif bash function
-[group('Utility')]
-[private]
-sudoif command *args:
-    #!/usr/bin/bash
-    function sudoif(){
-        if [[ "${UID}" -eq 0 ]]; then
-            "$@"
-        elif [[ "$(command -v sudo)" && -n "${SSH_ASKPASS:-}" ]] && [[ -n "${DISPLAY:-}" || -n "${WAYLAND_DISPLAY:-}" ]]; then
-            /usr/bin/sudo --askpass "$@" || exit 1
-        elif [[ "$(command -v sudo)" ]]; then
-            /usr/bin/sudo "$@" || exit 1
-        else
-            exit 1
-        fi
-    }
-    sudoif {{ command }} {{ args }}
+    ${SUDOIF} {{ just }} clean
 
 # This Justfile recipe builds a container image using Podman.
 #
@@ -253,16 +245,16 @@ _rootful_load_image $target_image=image_name $tag=default_tag:
 
     if [[ $return_code -eq 0 ]]; then
         # If the image is found, load it into rootful podman
-        ID=$({{ just }} sudoif podman images --filter reference="${target_image}:${tag}" --format "'{{ '{{.ID}}' }}'")
+        ID=$(${SUDOIF} podman images --filter reference="${target_image}:${tag}" --format "'{{ '{{.ID}}' }}'")
         if [[ "$ID" != "$USER_IMG_ID" ]]; then
             # If the image ID is not found or different from user, copy the image from user podman to root podman
             COPYTMP=$(mktemp -p "${PWD}" -d -t _build_podman_scp.XXXXXXXXXX)
-            {{ just }} sudoif TMPDIR=${COPYTMP} podman image scp ${UID}@localhost::"${target_image}:${tag}" root@localhost::"${target_image}:${tag}"
+            ${SUDOIF} TMPDIR=${COPYTMP} podman image scp ${UID}@localhost::"${target_image}:${tag}" root@localhost::"${target_image}:${tag}"
             rm -rf "${COPYTMP}"
         fi
     else
         # If the image is not found, pull it from the repository
-        {{ just }} sudoif podman pull "${target_image}:${tag}"
+        ${SUDOIF} podman pull "${target_image}:${tag}"
     fi
 
 # Build a bootc bootable image using Bootc Image Builder (BIB)
@@ -444,7 +436,7 @@ install-cosign:
         podman rmi -f {{ cosign-installer }}
 
         # Install
-        {{ just }} sudoif install -c -m 0755 "$TMPDIR"/cosign /usr/local/bin/cosign
+        ${SUDOIF} install -c -m 0755 "$TMPDIR"/cosign /usr/local/bin/cosign
 
         # Verify Cosign Image Signatures if needed
         if ! cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/cosign >/dev/null; then
@@ -472,7 +464,7 @@ install-syft:
         podman rmi -f {{ syft-installer }}
 
         # Install
-        {{ just }} sudoif install -c -m 0755 "$TMPDIR"/syft /usr/local/bin/syft
+        ${SUDOIF} install -c -m 0755 "$TMPDIR"/syft /usr/local/bin/syft
     fi
 
 # Get Cosign if Needed
@@ -589,6 +581,14 @@ sbom-attest input $sbom="" $destination="": install-cosign
         "${SBOM_ATTEST_ARGS[@]}" \
         "$destination/{{ repo_image_name }}@${digest}"
 
+# Generate Default Tag
+[group('Utility')]
+generate-default-tag $tag=default_tag:
+    #!/usr/bin/env bash
+    set -eoux pipefail
+
+    echo "${tag}"
+
 # Generate Tags
 [group('Utility')]
 generate-build-tags $tag=default_tag $github_number="0" $base_version="":
@@ -618,20 +618,30 @@ generate-build-tags $tag=default_tag $github_number="0" $base_version="":
 
 # Tag Images
 [group('Utility')]
-tag-images image_name="" default_tag="" tags="":
+tag-images $image_name="" $tag="" tags="":
     #!/usr/bin/bash
     set -eou pipefail
 
     # Get Image, and untag
-    IMAGE=$(podman inspect localhost/{{ image_name }}:{{ default_tag }} --format '{{{{.Id}}')
+    IMAGE=$(podman inspect localhost/${image_name}:${tag} --format '{{{{.Id}}')
+    ${PODMAN} untag ${IMAGE}
 
     # Tag Image
     for tag in {{ tags }}; do
-        podman tag $IMAGE {{ image_name }}:${tag}
+        podman tag $IMAGE ${image_name}:${tag}
     done
 
     # Show Images
     podman images --filter id=$IMAGE
+
+# Image Name
+[group('Utility')]
+[private]
+image_name $target_image=image_name:
+    #!/usr/bin/env bash
+    set -eoux pipefail
+
+    echo "${image_name}"
 
 # Login to GHCR
 [group('CI')]
@@ -653,7 +663,34 @@ push-to-registry $image_name $default_tag $tags="" registry=IMAGE_REGISTRY:
     echo "$digest"
 
 [group('Utility')]
-rechunk $target_image=image_name $tag=default_tag:
+rechunk $image=image_name $tag=default_tag:
+    #!/usr/bin/env bash
+    set ${SET_X:+-x} -eou pipefail
+
+    CHUNKAH_OUTPUT_DIR="$(mktemp -d)"
+    CHUNKAH_CONFIG_FILE="$(mktemp)"
+
+    trap 'rm -f "${CHUNKAH_CONFIG_FILE}"; rm -rf "${CHUNKAH_OUTPUT_DIR}"' EXIT
+    ${PODMAN} inspect "${image_name}:${tag}" > "${CHUNKAH_CONFIG_FILE}"
+
+    ${PODMAN} run --rm --mount=type=image,src="${image_name}:${tag}",target=/chunkah \
+    -v "${CHUNKAH_CONFIG_FILE}:/chunkah-config.json:ro,Z" \
+    -v "${CHUNKAH_OUTPUT_DIR}:/run/out:Z" \
+    "{{ chunkah }}" \
+    build \
+    --verbose \
+    --compressed \
+    --max-layers 256 \
+    --prune /sysroot/ \
+    --label ostree.commit- --label ostree.final-diffid- \
+    --config /chunkah-config.json \
+    --output oci:/run/out/chunked
+
+    CHUNKED_IMAGE="$(podman pull "oci:${CHUNKAH_OUTPUT_DIR}/chunked")"
+    podman tag "${CHUNKED_IMAGE}" "${image_name}:${tag}"
+
+[group('Utility')]
+rechunk-ostree $target_image=image_name $tag=default_tag:
     #!/usr/bin/env bash
     set ${SET_X:+-x} -eou pipefail
 

--- a/build_files/desktop-packages.sh
+++ b/build_files/desktop-packages.sh
@@ -102,11 +102,11 @@ LAYERED_PACKAGES+=(
     starship
 )
 
-# Cider music app
+# # Cider music app
 
-LAYERED_PACKAGES+=(
-    Cider
-)
+# LAYERED_PACKAGES+=(
+#     Cider
+# )
 
 dnf5 install --setopt=install_weak_deps=False -y "${LAYERED_PACKAGES[@]}"
 

--- a/build_files/desktop-packages.sh
+++ b/build_files/desktop-packages.sh
@@ -103,8 +103,7 @@ LAYERED_PACKAGES+=(
 )
 
 # Cider music app
-log "Import Cider Collective RPM key"
-rpm --import /usr/share/veneos/RPM-GPG-KEY-CIDER-COLLECTIVE
+
 LAYERED_PACKAGES+=(
     Cider
 )

--- a/image-versions.yml
+++ b/image-versions.yml
@@ -23,6 +23,12 @@ images:
     tag: testing
     digest: sha256:fd4a14d22c4e7327ea6a282283fb820f5168d139984245c4b1586a1738bb0614
 
+  # https://github.com/coreos/chunkah
+  - name: chunkah
+    image: quay.io/coreos/chunkah
+    tag: latest
+    digest: sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708
+
 veneos:
   - tag: stable
     upstream: *bazzite

--- a/system_files/etc/yum.repos.d/cidercollective.repo
+++ b/system_files/etc/yum.repos.d/cidercollective.repo
@@ -1,6 +1,6 @@
 [cidercollective]
 name=Cider Collective Repository
 baseurl=https://repo.cider.sh/rpm/RPMS
-enabled=1
+enabled=0
 gpgcheck=1
 gpgkey=file:///usr/share/veneos/RPM-GPG-KEY-CIDER-COLLECTIVE

--- a/system_files/etc/yum.repos.d/cidercollective.repo
+++ b/system_files/etc/yum.repos.d/cidercollective.repo
@@ -3,4 +3,4 @@ name=Cider Collective Repository
 baseurl=https://repo.cider.sh/rpm/RPMS
 enabled=1
 gpgcheck=1
-gpgkey=/usr/share/veneos/RPM-GPG-KEY-CIDER-COLLECTIVE
+gpgkey=file:///usr/share/veneos/RPM-GPG-KEY-CIDER-COLLECTIVE

--- a/veneos.env
+++ b/veneos.env
@@ -1,0 +1,13 @@
+IMAGE_NAME="veneos"
+REPO_ORGANIZATION="venefilyn"
+REPO_OWNER_ID="6598829"
+
+IMAGE_DESC="My Customized Bootc Image"
+IMAGE_KEYWORDS="bootc,oci,linux"
+
+IMAGE_LOGO_URL="https://avatars.githubusercontent.com/u/6598829?s=200&v=4"
+DEFAULT_TAG="STABLE"
+BIB_IMAGE="quay.io/centos-bootc/bootc-image-builder:latest"
+
+CENTOS_VERSION="stream10"
+FEDORA_VERSION="42"


### PR DESCRIPTION
Match parts of Aurora and image-template upstream ublue repos. Changes
the chunker from ostree based one to chunkah and improves workflow to
handle it.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
